### PR TITLE
Allows for copying all entries in localstorage when updating to WKWeb…

### DIFF
--- a/src/ios/MigrateLocalStorage.m
+++ b/src/ios/MigrateLocalStorage.m
@@ -48,8 +48,6 @@
     }
     
     // Migrate UIWebView local storage files to WKWebView. Adapted from:
-    // https://github.com/SwitchCaseGroup/switchcase-cordova-plugin-migrate-localstorage/blob/master/src/ios/MigrateLocalStorage.m
-    // And theirs from:
     // https://github.com/Telerik-Verified-Plugins/WKWebView/blob/master/src/ios/MyMainViewController.m
     
     NSString* appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];

--- a/src/ios/MigrateLocalStorage.m
+++ b/src/ios/MigrateLocalStorage.m
@@ -5,59 +5,84 @@
 - (BOOL) copyFrom:(NSString*)src to:(NSString*)dest
 {
     NSFileManager* fileManager = [NSFileManager defaultManager];
-
+    
     // Bail out if source file does not exist
     if (![fileManager fileExistsAtPath:src]) {
         return NO;
     }
-
+    
     // Bail out if dest file exists
     if ([fileManager fileExistsAtPath:dest]) {
         return NO;
     }
-
+    
     // create path to dest
     if (![fileManager createDirectoryAtPath:[dest stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:nil]) {
         return NO;
     }
-
+    
     // copy src to dest
     return [fileManager copyItemAtPath:src toPath:dest error:nil];
 }
 
 - (void) migrateLocalStorage
 {
-    // Migrate UIWebView local storage files to WKWebView. Adapted from
-    // https://github.com/Telerik-Verified-Plugins/WKWebView/blob/master/src/ios/MyMainViewController.m
+    NSError *error;
+    
+    NSArray *cachePaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    NSString *cacheDirectory = [cachePaths objectAtIndex:0];
+    
+    NSArray *cacheDirectoryItems = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:cacheDirectory error:&error];
+//    NSLog(@"%@", cacheDirectoryItems);  // Print directory items to log
+    
+    NSMutableArray *cacheLocalStorageItems = [NSMutableArray arrayWithCapacity:1000];
+    
+    // Filter out LocalStorage files from cache and copy to cacheLocalStorageItems
+    for(int i = 0; i < cacheDirectoryItems.count; i++){
+        if([cacheDirectoryItems[i] rangeOfString:@".localstorage"].location == NSNotFound){
 
-    NSString* appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    NSString* original;
+        }else{
 
-    if ([[NSFileManager defaultManager] fileExistsAtPath:[appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage/file__0.localstorage"]]) {
-        original = [appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage"];
-    } else {
-        original = [appLibraryFolder stringByAppendingPathComponent:@"Caches"];
+            [cacheLocalStorageItems addObject:[cacheDirectoryItems objectAtIndex:i]];
+        }
     }
-
-    original = [original stringByAppendingPathComponent:@"file__0.localstorage"];
-
+    
+    // Migrate UIWebView local storage files to WKWebView. Adapted from:
+    // https://github.com/SwitchCaseGroup/switchcase-cordova-plugin-migrate-localstorage/blob/master/src/ios/MigrateLocalStorage.m
+    // And theirs from:
+    // https://github.com/Telerik-Verified-Plugins/WKWebView/blob/master/src/ios/MyMainViewController.m
+    
+    NSString* appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    NSString* original = @"";
+    
+    if (![[NSFileManager defaultManager] fileExistsAtPath:[appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage/file__0.localstorage"]]) {
+        original = [appLibraryFolder stringByAppendingPathComponent:@"Caches"];
+    }else{
+        return;
+    }
+    
     NSString* target = [[NSString alloc] initWithString: [appLibraryFolder stringByAppendingPathComponent:@"WebKit"]];
-
+    
 #if TARGET_IPHONE_SIMULATOR
     // the simulutor squeezes the bundle id into the path
     NSString* bundleIdentifier = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
     target = [target stringByAppendingPathComponent:bundleIdentifier];
 #endif
 
-    target = [target stringByAppendingPathComponent:@"WebsiteData/LocalStorage/file__0.localstorage"];
-
-    // Only copy data if no existing localstorage data exists yet for wkwebview
-    if (![[NSFileManager defaultManager] fileExistsAtPath:target]) {
-        NSLog(@"No existing localstorage data found for WKWebView. Migrating data from UIWebView");
-        [self copyFrom:original to:target];
-        [self copyFrom:[original stringByAppendingString:@"-shm"] to:[target stringByAppendingString:@"-shm"]];
-        [self copyFrom:[original stringByAppendingString:@"-wal"] to:[target stringByAppendingString:@"-wal"]];
-    }
+    NSString* wkWebViewStoragePath = [target stringByAppendingPathComponent:@"WebsiteData/LocalStorage/file__0.localstorage"];
+    
+    target = [target stringByAppendingPathComponent:@"WebsiteData/LocalStorage"];
+    
+        if (![[NSFileManager defaultManager] fileExistsAtPath:wkWebViewStoragePath]) {
+            
+            for(int i = 0; i < cacheLocalStorageItems.count; i++){
+                
+                [self copyFrom:[original stringByAppendingPathComponent:cacheLocalStorageItems[i]] to:[target stringByAppendingPathComponent:cacheLocalStorageItems[i]]];
+                
+            }
+            
+        }
+    
 }
 
 - (void)pluginInitialize


### PR DESCRIPTION
Changes to iterate through the cache directory to copy over all entries with localstorage in their name, allowing all of localstorage to be copied over when upgrading to WKWebview. Just copies from old location to new location for persistence.